### PR TITLE
Fixes 2 pages for runbooks

### DIFF
--- a/source/documentation/joiners-leavers/leavers.html.erb.md
+++ b/source/documentation/joiners-leavers/leavers.html.erb.md
@@ -1,0 +1,8 @@
+---
+owner_slack: "#operations-engineering-alerts"
+title: Leavers Process
+last_reviewed_on: 2023-08-30
+review_in: 3 months
+---
+
+# Leavers Process

--- a/source/documentation/joiners-leavers/new-joiners.html.erb.md
+++ b/source/documentation/joiners-leavers/new-joiners.html.erb.md
@@ -1,0 +1,8 @@
+---
+owner_slack: "#operations-engineering-alerts"
+title: Joiners Process
+last_reviewed_on: 2023-08-30
+review_in: 3 months
+---
+
+# Joiners Process


### PR DESCRIPTION
This PR adds headings to the joiners/leavers pages.  Currently they are blank and this is causing the build to fail as pages need at least 1 heading.