### PR TITLE
Fixes internal links for runbooks

### DIFF
--- a/source/documentation/internal/how-to-support.html.erb.md
+++ b/source/documentation/internal/how-to-support.html.erb.md
@@ -44,7 +44,7 @@ When you've completed the required action, add the `closed` label to the email.
 
 A few examples of the types of requests you'll receive in these mailboxes are:
 
-- [Respond to certificates that have expired/about to expire](../certificates/respond-to-expired-certificates.html)
+- [Respond to certificates that have expired/about to expire](../../certificates/respond-to-expired-certificates.html)
 - [Respond to leavers forms and remove their access](respond-to-leavers.html)
 
   3. Review documentation that has expired

--- a/source/documentation/internal/team/new-joiners.html.erb.md
+++ b/source/documentation/internal/team/new-joiners.html.erb.md
@@ -26,7 +26,7 @@ Add new team members to `#operations-engineering-team`, `#operations-engineering
 
 ## Ops-Engineering site
 
-This [site](https://operations-engineering.service.justice.gov.uk/#moj-operations-engineering) explains the Tools below. Details of vision for team, how we work, all our services, code and runbooks.
+This [site](https://user-guides.operations-engineering.service.justice.gov.uk/#moj-operations-engineering-user-guides) explains the Tools below. Details of vision for team, how we work, all our services, code and runbooks.
 
 ## Technical Guidance site
 
@@ -38,7 +38,7 @@ Setup a new account on [Github](https://github.com/) or assign the digital justi
 
 ## MoJ Github
 
-Runbook: [Add user to GitHub](../services/add-github-user.html)
+Runbook: [Add user to GitHub](../../services/github/add-github-user.html)
 
 After the invitation has been accepted, check access to the [Ministry of Justice organisation](https://github.com/ministryofjustice) and the [moj-analytical-services organisation](https://github.com/orgs/moj-analytical-services).
 
@@ -62,7 +62,7 @@ A google account will enable log-ins to some/most of these tools MOJ provision h
 
 A team member will send you an email invite to join 1Password.
 
-Runbook: [Add New Users to 1Password](../services/add-new-user-1password.html)
+Runbook: [Add New Users to 1Password](../../services/1password/1password-add-new-user.html)
 
 Add to **Administrators** Group.
 
@@ -109,7 +109,7 @@ Creds in Ops Eng Folder in LastPass. Will be in the shared area of passwords.
 
 ## Docker
 
-Runbook: [Add user to Docker](../services/add-docker-user.html)
+Runbook: [Add user to Docker](../../services/docker/add-docker-user.html)
 
 ## [Auth0](https://auth0.com/)
 

--- a/source/documentation/services/1password/1password-add-new-user.html.erb.md
+++ b/source/documentation/services/1password/1password-add-new-user.html.erb.md
@@ -13,10 +13,10 @@ These processes are for adding new users to the Ministry of Justice Enterprise 1
 
 Before you begin, there are a few pre-requisites:
 
-* Access to [1Password Dashboard](https://ministryofjustice.1password.eu/home)
-* New user name and work email address
-* Details of the shared Vault that the user needs adding to
-* Approval from Vault Owner to add new user (unless the Group they want to be added to has the approver set as Manager)
+- Access to [1Password Dashboard](https://ministryofjustice.1password.eu/home)
+- New user name and work email address
+- Details of the shared Vault that the user needs adding to
+- Approval from Vault Owner to add new user (unless the Group they want to be added to has the approver set as Manager)
 
 Note - Owner details are stored in the Vault Description field within 1Password
 

--- a/source/documentation/services/1password/1password-add-new-user.html.erb.md
+++ b/source/documentation/services/1password/1password-add-new-user.html.erb.md
@@ -1,0 +1,53 @@
+---
+owner_slack: "#operations-engineering-alerts"
+title: Add New Users to 1Password
+last_reviewed_on: 2023-09-01
+review_in: 3 months
+---
+
+# Add New Users to 1Password
+
+These processes are for adding new users to the Ministry of Justice Enterprise 1Password account.
+
+## Pre-requisites
+
+Before you begin, there are a few pre-requisites:
+
+* Access to [1Password Dashboard](https://ministryofjustice.1password.eu/home)
+* New user name and work email address
+* Details of the shared Vault that the user needs adding to
+* Approval from Vault Owner to add new user (unless the Group they want to be added to has the approver set as Manager)
+
+Note - Owner details are stored in the Vault Description field within 1Password
+
+**1Password is only available to MoJ users/teams. We do not give access to 3rd party suppliers or anyone without an @digital.justice.gov.uk, @justice.gov.uk or @cica.gov.uk email address.**
+
+**1Password is also only for shared Team credentials. Users must be added to a ["Group"](https://support.1password.com/custom-groups/). If access is just for personal use only, refer them to the [Technology Portal](https://mojprod.service-now.com/moj_sp).**
+
+**Note - This is a two step process. A user will be invited to join the organisation (create an account, set up 2FA and install app etc). The users will then need to be added to the correct Group to enable access to a shared Vault.**
+
+## Step 1 - Issue invite
+
+1. Login to the 1Password Dashboard
+
+2. Click on the "+" on the invitations section to bring up the box to add the users email address.
+
+3. Add user email address and Click on the "Invite" button to submit. You can add multiple users one time. The user will be issued with an invitation email.
+
+## Step 2 - Add user to Group
+
+> Please note that if the Group has a Manager set already, they can add the user to the Group themselves
+
+1. When the user has successfully created an account we will receive a notification to #operations-engineering-alerts slack channel.
+
+2. Clicking on the link in the notification will take you to the admin dashboard where you can **Confirm** that the user is part of the MoJ organisation. You can do this via the "Awaiting Confirmation" section of the dashboard or by clicking on the Notification Bell (top right).
+
+3. Now add the user to the Group that will set permissions for shared vaults. Navigate to the **Groups** page.
+
+**Note - Most Vaults are associated with Groups with the same name, however in somecases this is not the case. You can check which Group has access to a specific Vault by viewing the Vault details.**
+
+4. Find the correct Group and click on it to see Group Details.
+
+5. Click on **Manage** button and find the users to add to the Group.
+
+6. Save changes by clicking on the **Update Group Members** button. The user will now be able to see their shared Vaults.

--- a/source/documentation/services/sentryio/respond-to-sentry-usage-alert.html.erb.md
+++ b/source/documentation/services/sentryio/respond-to-sentry-usage-alert.html.erb.md
@@ -64,7 +64,7 @@ teams join Sentry and applications gain more traffic.
 
 ## Remediation
 
-Read through the [comment]: # ([Sentry Service Documentation](./../../services/sentry.html)) and ensure high usage projects are
+Read through the [Sentry Service Documentation](https://github.com/ministryofjustice/operations-engineering-user-guide/source/documentation/services/sentry.html.md.erb) and ensure high usage projects are
 following the quota management guidance.
 
 If a project isn't following the guidance, contact the team to understand if there's any particular reason for their

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -83,7 +83,7 @@ These runbooks are designed to provide information and instructions to the Opera
 
 * [Create a Sentry Internal Integration](documentation/services/sentryio/sentry-internal-integrations.html)
 * [Disabling sending errors to a project in Sentry](documentation/services/sentryio/disable-sentry-errors.html)
-* [Respond to Sentry Usage Alerts](documentation/services/sentryio/respond-to-sentry-usage-alerts.html)
+* [Respond to Sentry Usage Alerts](documentation/services/sentryio/respond-to-sentry-usage-alert.html)
 
 ## SonarCloud
 


### PR DESCRIPTION
This PR fixes 5 internal links that were not properly mapped and 1 external link to the user guide repository, which are preventing the deployment of the previous update.