### PR TITLE
Add link to ignore list

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -13,3 +13,4 @@ https://operations-engineering-reports.cloud-platform.service.justice.gov.uk/api
 https://operations-engineering-reports.cloud-platform.service.justice.gov.uk/public-report/REPO-NAME
 https://github.com/ministryofjustice/operations-engineering-runbooks/issues/*
 https://drive.google.com/*
+https://docs.google.com/spreadsheets/d/1gAVhX8Ts-BuhZRNBEF-80UUjlnYyyMKKBQ4ZPnHPZmE/edit?usp=sharing


### PR DESCRIPTION
This PR adds the Certificate Owners Google Sheet to the ignore list. As this sheet requests authentication the link checker is failing.