### PR TITLE
:sparkles: Add ADR for GitHub Updates RSS Feed Integration

### DIFF
--- a/source/documentation/adrs/adr-012.html.erb.md
+++ b/source/documentation/adrs/adr-012.html.erb.md
@@ -1,0 +1,58 @@
+---
+owner_slack: "#operations-engineering-alerts"
+title: ADR-012 Implementing an RSS Feed Aggregation Channel for GitHub Updates
+last_reviewed_on: 2023-11-09
+review_in: 6 months
+---
+
+# ADR-012: Implementing an RSS Feed Aggregation Channel for GitHub Updates
+
+## Status
+
+✅ Accepted
+
+## Context
+
+As a GitHub Administrator, it is critical to stay abreast of new settings or features introduced by GitHub to assess their impact on our workflows, security, and compliance requirements. Timeliness in this information is essential to leverage new functionalities for improved efficiency, better security practices, and an enhanced user experience.
+
+## Decision
+
+To address this need, we have created a Slack channel named #operations-engineering-rss. This channel is subscribed to various RSS feeds that provide updates on GitHub's latest developments, including new features, policy changes, security updates, and more.
+
+The following feeds have been subscribed to:
+
+- Stack Overflow questions tagged GitHub
+
+- Hacker Noon articles tagged GitHub
+
+- Hacker News best stories with GitHub
+
+- GitHub Blog for various categories including Policy, Community, Enterprise, Security, Product, and Engineering updates
+
+- Git Rev News
+
+- GitHub Changelog
+
+## Consequences
+
+The channel allows for prompt delivery of pertinent GitHub updates to the right stakeholders without overwhelming them with non-essential information. It aids in maintaining an informed team that can quickly respond and adapt to changes.
+
+The decision to use Slack for aggregating RSS feeds ensures that updates are pushed to a platform where our team is already active, thus reducing the friction in communication and ensuring a higher likelihood of updates being seen and acted upon promptly.
+
+This channel will also act as a trigger for our internal review process to evaluate each new setting or feature's relevance, benefits, and impact on our current setup.
+
+## Trade-offs
+
+While this approach centralises information, there is a risk of information overload. To mitigate this, careful curation and prioritisation of updates are required to ensure only relevant updates are communicated.
+
+The success of this channel relies heavily on the RSS feeds' uptime and reliability, which are external services that we do not control.
+
+## Next Steps
+
+To complete this initiative, we will:
+
+- Implement a filter mechanism to highlight or prioritise high-impact updates.
+
+- Establish a clear review and feedback process to assess the relevance and impact of updates.
+
+- Update our documentation and policies in accordance with the latest changes from GitHub.


### PR DESCRIPTION
Connects to https://github.com/ministryofjustice/operations-engineering/issues/3795

Created an ADR documenting the decision to implement a Slack channel (#operations-engineering-rss) subscribed to key RSS feeds for real-time GitHub updates. This enables prompt alerting of new features and settings, facilitating quicker assessments of their impact on our workflows, security, and compliance.
