### PR TITLE
:sparkles: Add ADR015: Use GitHub Actions Runner Controller

### DIFF
--- a/source/documentation/adrs/adr-015.html.erb.md
+++ b/source/documentation/adrs/adr-015.html.erb.md
@@ -1,0 +1,46 @@
+---
+owner_slack: "#operations-engineering-alerts"
+title: ADR 015 Use of GitHub Actions Runner Controller in Cloud Platform
+last_reviewed_on: 2023-11-27
+review_in: 6 months
+---
+
+# ADR-015: Use of GitHub Actions Runner Controller in Cloud Platform
+
+## Status
+
+❌ Rejected
+
+## Context:
+
+Our organisation aimed to implement GitHub Actions Runner Controller within our Cloud Platform to manage CI/CD processes for private repositories efficiently. This approach was expected to increase autonomy, reduce costs, and avoid limitations set by external CI/CD services.
+
+## Decision:
+
+After careful consideration, we have decided not to proceed with the implementation of GitHub Actions Runner Controller on our Cloud Platform. This decision is based on the incompatibility between GitHub Actions' requirements and our Cloud Platform's security policies.
+
+- **GitHub Actions Requirement**: GitHub Actions necessitates that runners operate as the root user in a Docker environment. This is essential for the correct functioning of GitHub Actions ([GitHub Documentation](https://docs.github.com/en/actions/creating-actions/dockerfile-support-for-github-actions#user)).
+
+- **Cloud Platform Policy**: Our Cloud Platform strictly prohibits the creation of pods that operate as the root user or have access to the root file system. This policy is crucial for maintaining the platform's security and preventing potential vulnerabilities.
+
+## Consequences:
+
+1. **Security Maintenance**: By adhering to our Cloud Platform's security policies, we maintain the high security standards essential for our organization's operations.
+
+2. **Operational Consistency**: This decision ensures consistency in our operational practices and avoids setting a precedent for policy exceptions.
+
+## Alternatives Considered:
+
+1. **Policy Exception for GitHub Actions**: This was deemed too risky due to the potential security vulnerabilities it could introduce.
+
+2. **Use of External CI/CD Services**: Continuation with external CI/CD services like GitHub-hosted runners, albeit with limitations in control and potential cost implications.
+
+3. **Exploring Other CI/CD Tools**: Investigating other CI/CD tools that comply with our security policies and can be integrated into our Cloud Platform.
+
+## Decision Rationale:
+
+The primary rationale behind this decision is the commitment to maintaining the highest level of security and integrity in our Cloud Platform operations. The potential security risks associated with running GitHub Actions runners as root users are in direct conflict with our established security policies.
+
+## Future Considerations:
+
+This decision should be revisited if either GitHub Actions changes its requirements to be more aligned with our security policies, or if our Cloud Platform evolves to accommodate such requirements in a secure manner.

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -158,6 +158,7 @@ To understand why we are recording decisions and how we are doing it, please see
 | ✅ | ADR-012 | [RSS Feed Aggregation Channel](documentation/adrs/adr-012.html) |
 | ✅ | ADR-013 | [Archiving the DNS repo](documentation/adrs/adr-013.html) |
 | ✅ | ADR-014 | [Risk Review](documentation/adrs/adr-014.html) |
+| ❌ | ADR-015 | [Use of GitHub Actions Runner Controller](documentation/adrs/adr-015.html) |
 
 **Statuses:**
 


### PR DESCRIPTION
- Added a detailed report outlining the challenges encountered in
implementing the GitHub Actions Runner Controller on our Cloud Platform.

- The report highlights the core issue of incompatibility between GitHub
Actions' requirement for runners to operate as root users and our Cloud
Platform's strict security policy against root user operations.

- It discusses the potential security risks associated with making an
exception to our Cloud Platform's policy, which would significantly
increase the attack surface.

- This document serves as a basis for future decision-making and
discussions regarding our CI/CD processes and security policies.

[Full
report](https://github.com/ministryofjustice/operations-engineering/issues/3759#issuecomment-1827664314)
