### PR TITLE
:green_heart: Replace link checker resource

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Link Checker
+        uses: lycheeverse/lychee-action@v1.8.0
+        with:
+          fail: true
+          args: --verbose --exclude-mail --no-progress './**/*.md' './**/*.html' './**/*.erb' --accept 403,200,429
       - name: Compile Markdown to HTML and create artifact
         run: |
           /scripts/deploy.sh
@@ -22,35 +27,3 @@ jobs:
           name: github-pages-test
           path: artifact.tar
           retention-days: 1
-
-  url-check:
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download a Build Artifact from build
-        uses: actions/download-artifact@v3
-        with:
-          name: github-pages-test
-          path: github-pages-test
-      - name: Unpack files and check URL links
-        run: |
-          cd github-pages-test
-          tar -xvf artifact.tar
-          npm install linkinator
-          npx linkinator . --recurse --markdown \
-            --skip https://groups.google.com/* \
-            --skip https://github.com/ministryofjustice/dns \
-            --skip https://github.com/ministryofjustice/moj-ip-addresses \
-            --skip https://github.com/ministryofjustice/mta-sts \
-            --skip https://manage.auth0.com/dashboard/eu/moj-uk \
-            --skip https://github.com/orgs/ministryofjustice/teams/operations-engineering \
-            --skip https://github.com/organizations/ministryofjustice/settings/installations/16911235 \
-            --skip https://runbooks.operations-engineering.service.justice.gov.uk/images/govuk-large.png \
-            --skip https://github.com/ministryofjustice/%7BPROJECT_NAME%7D/settings/keys \
-            --skip https://github.com/ministryofjustice/operations-engineering-runbooks/issues/* \
-            --skip https://drive.google.com/file/d/1eYCm5PqpsQXKQdT_XhNi-wbH4976t9M5/view?usp=sharing \
-            --skip https://docs.google.com/document/d/1KvreqmI_P6E7YLpdRrjefv1fo6B3-B6JBz4MAGiL0Jw/edit#heading=h.33v5b0ui54nd \
-            --skip https://docs.google.com/spreadsheets/d/1lZ2ffiN_yQEYqTYnBzTbl16iElfrp3rZ8JnznDQWc-g/edit?usp=sharing \
-            --skip https://docs.google.com/spreadsheets/d/1gAVhX8Ts-BuhZRNBEF-80UUjlnYyyMKKBQ4ZPnHPZmE/edit?usp=sharing \
-            --skip https://github.com/ministryofjustice/data-platform-support/issues/new/choose \
-          # "URL Check will fail on private and internal GitHub repositories"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,11 +13,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Link Checker
-        uses: lycheeverse/lychee-action@v1.8.0
-        with:
-          fail: true
-          args: --verbose --exclude-mail --no-progress './**/*.md' './**/*.html' './**/*.erb' --accept 403,200,429
       - name: Compile Markdown to HTML and create artifact
         run: |
           /scripts/deploy.sh
@@ -27,3 +22,13 @@ jobs:
           name: github-pages-test
           path: artifact.tar
           retention-days: 1
+
+  linkChecker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Link Checker
+        uses: lycheeverse/lychee-action@v1.8.0
+        with:
+          fail: true
+          args: --verbose --exclude-mail --no-progress './**/*.md' './**/*.html' './**/*.erb' --accept 403,200,429


### PR DESCRIPTION
We currently have a link checker that runs overnight; we should use one tool to achieve this across the whole repository
