### PR TITLE
Move Dormant User index link to Github section

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#operations-engineering-alerts"
 title: MoJ Operations Engineering Runbooks
-last_reviewed_on: 2024-01-02
+last_reviewed_on: 2024-01-03
 review_in: 6 months
 ---
 
@@ -74,6 +74,7 @@ refer users to.
 * [Add GitHub collaborators from a fork PR](documentation/services/github/add-collaborators-from-fork.html)
 * [Branch Protection Settings and Issues](documentation/services/github/branch-protection-settings.html)
 * [How to respond to a low GitHub seats alert](documentation/internal/low-github-seats-procedure.html)
+* [Dormant User Process](documentation/internal/dormant-user-process.html)
 
 ## OS Data Hub
 
@@ -125,7 +126,6 @@ refer users to.
 
 * [Add a Runbook](documentation/internal/add-a-runbook.html)
 * [Add a Slack Alert to our Alert Channel](documentation/internal/add-slack-alert.html)
-* [Dormant User Process](documentation/internal/dormant-user-process.html)
 * [Issue Labelling](documentation/internal/issue-labelling.html)
 * [Manage Slack RSS Feeds](documentation/internal/add-remove-rss-feeds.html)
 * [Python Best Practise](documentation/internal/python-best-practise.html)


### PR DESCRIPTION
This runbook specifically relates to Github administration so adding it to the Github section. Makes it easier to find.