### PR TITLE
:memo: Tracking and Actioning Risk Review Items

### DIFF
--- a/source/documentation/internal/risk-review.html.md.erb
+++ b/source/documentation/internal/risk-review.html.md.erb
@@ -33,7 +33,7 @@ This runbook outlines the process for conducting a risk review meeting for the O
 - **Review Dates:** Pay special attention to risks with overdue review dates, as highlighted by the conditional formatting in the register.
 - **Actionable Insights:** Discuss actionable insights and decisions affecting risk register entries.
 
-**Measuring Likelihood and Impact of Risks**
+## Measuring Likelihood and Impact of Risks
 
 To effectively assess and prioritise risks, we use a systematic approach to measure both the likelihood and impact of each identified risk. This approach involves assigning scores on a scale of 1 to 5 for both likelihood and impact, and then calculating a risk score to determine the overall severity of the risk.
 
@@ -111,8 +111,18 @@ Update the review dates for each risk and discuss any risks nearing the review p
 
 Summarise the meeting outcomes and next steps.
 
+## Tracking and Actioning Risk Review Items
+
+To ensure that all actions identified in the risk review meetings are captured and followed through effectively, a dedicated tab called 'Actions' has been added to our risk review spreadsheet. This tab is designed to improve the tracking, accountability, and completion of action items.
+
+### Benefits:
+
+- Improved accountability and visibility of action items.
+- Ensures that risk-related actions are not overlooked.
+- Provides a historical record of actions taken in response to identified risks.
+
 ## Post-Meeting Actions
 
 1. Update the risk register with any changes or new information.
-2. Share the meeting minutes, including action items and deadlines, with all participants and relevant stakeholders.
+2. Share the meeting minutes with all participants and relevant stakeholders, including action items and deadlines.
 3. Ensure follow-up on assigned actions and prepare for interim reviews if needed.


### PR DESCRIPTION
## 👀 Purpose

This pull request introduces a new section to our Risk Review Meeting Process document, focusing on the 'Tracking and Actioning Risk Review Items'. The purpose is to capture, track, and complete action items identified during risk review meetings.

## ♻️ What's changed

- Added a new section titled 'Tracking and Actioning Risk Review Items' after the 'Meeting Structure' section of the Risk Review Meeting Process document.
- Included information on the benefits of this new process in terms of accountability, visibility, and historical record-keeping.

## 📝 Notes

