### PR TITLE
:memo: Create repository naming convention ADR

### DIFF
--- a/source/documentation/adrs/adr-018.html.md.erb
+++ b/source/documentation/adrs/adr-018.html.md.erb
@@ -1,0 +1,35 @@
+---
+owner_slack: "#operations-engineering-alerts"
+title: ADR-018 Standardisation of Repository Naming for Operations Engineering
+last_reviewed_on: 2024-01-26
+review_in: 6 months
+---
+
+# ADR-018 Standardisation of Repository Naming for Operations Engineering
+
+## Status
+
+✅ Accepted
+
+## Context
+
+The Operations Engineering (OE) team at the Ministry of Justice (MoJ) recognised the need for a standardised approach to naming our repositories to improve clarity, organisation, and navigability. Discussions revealed the importance of differentiating between repositories the team owns and those it acts as a custodian for within the broader organisation.
+
+## Decision
+
+We have decided to adopt a dual approach to our repository naming conventions:
+
+1. **Owned Repositories**: Repositories exclusively developed, managed, and used by the OE team will follow the `operations-engineering-*` naming convention. These are primarily internal tools, scripts, or resources utilised by our team.
+
+2. **Custodian Repositories**: For repositories where the OE team acts as a custodian for the entire MoJ, a more generic and descriptive naming convention will be used. These names will not include the `operations-engineering-` prefix to ensure they are perceived as organisation-wide resources rather than team-specific.
+
+## Consequences
+
+- Owned repositories will be renamed, ensuring minimal disruption and clear communication within the MoJ.
+- Custodian repositories will retain their current names or be named descriptively to reflect their use across the MoJ.
+- Clear guidelines will be established to categorise repositories as either owned or custodian.
+- The OE team will explore effective ways to track and manage our repository estate, respecting the dual nature of our responsibilities.
+
+## References
+
+- [GitHub Discussion](https://github.com/ministryofjustice/operations-engineering/discussions/4075)


### PR DESCRIPTION
## 👀 Purpose

- To align the repository naming conventions within the Operations Engineering team.

## ♻️ What's changed

- Adopted a dual naming approach: operations-engineering-* for owned repositories and generic, descriptive names for custodian repositories.

## 📝 Notes

- This PR connects to discussion https://github.com/ministryofjustice/operations-engineering/discussions/4075.
- This PR connects to project item https://github.com/orgs/ministryofjustice/projects/52/views/4?pane=issue&itemId=49271897