### PR TITLE
Update certificate funding guidance

### DIFF
--- a/source/documentation/certificates/manual-ssl-certificate-processes.html.md.erb
+++ b/source/documentation/certificates/manual-ssl-certificate-processes.html.md.erb
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#operations-engineering-alerts"
 title: Manual SSL Certificate Processes
-last_reviewed_on: 2023-11-16
+last_reviewed_on: 2024-02-16
 review_in: 3 months
 ---
 
@@ -139,6 +139,6 @@ The costs for Gandi.net certificates are met centrally by Platforms & Architectu
 
 MoJ has a prepaid account with Gandi.net for paying for certificates.
 
-If the account runs low a notification is sent to Certificate Alerts. If that happens contact [Software Asset Management](mailto:SoftwareAssetManagement@justice.gov.uk) to arrange a top-up on the account.
+If the account runs low a notification is sent to Certificate Alerts. If that happens speak to the Product Manager who will engage with the Demand Team to arrange additional funds.
 
 [gandi.net]: https://gandi.net


### PR DESCRIPTION
## 👀 Purpose

- This PR updates the certificate funding guidance following changes to the Commercial Process. We are no longer able to periodically to up the account and must use the Demand Process to fund the account on an annual basis. 

## ♻️ What's changed

- Updated process for funding the pre-paid account