### PR TITLE
Update Gov.uk documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ the [source](source) directory.
 
 The syntax used in `*.html.md.erb` is Markdown, though it also supports some
 GOV.UK Design System specifics, as listed on [Tech Docs Template - Write your
-content]([https://tdt-documentation.london.cloudapps.digital/write_docs/content/](https://github.com/alphagov/tdt-documentation/blob/main/source/write_docs/content/index.html.md.erb).
+content](https://github.com/alphagov/tdt-documentation/blob/main/source/write_docs/content/index.html.md.erb).
 
 ## Publishing changes
 
@@ -38,11 +38,11 @@ This website is hosted on [GitHub Pages](https://pages.github.com/).
 
 ### Global configuration
 
-The [GOV.UK Tech Docs Template global configuration options]([https://tdt-documentation.london.cloudapps.digital/configure_project/global_configuration/](https://github.com/alphagov/tdt-documentation/blob/main/source/configure_project/global_configuration/index.html.md.erb)
+The [GOV.UK Tech Docs Template global configuration options](https://github.com/alphagov/tdt-documentation/blob/main/source/configure_project/global_configuration/index.html.md.erb)
 can be used in this repository to configure the Operations Engineering user guides.
 
 ### Structuring documentation and page configuration
 
-The [GOV.UK Tech Docs Template "Configure your documentation project"]([https://tdt-documentation.london.cloudapps.digital/configure_project/](https://github.com/alphagov/tdt-documentation/blob/main/source/configure_project/index.html.md.erb)
+The [GOV.UK Tech Docs Template "Configure your documentation project"](https://github.com/alphagov/tdt-documentation/blob/main/source/configure_project/index.html.md.erb)
 offers a range of guidance regarding configuration options to help structure
 documentation and configure pages separately.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ the [source](source) directory.
 
 The syntax used in `*.html.md.erb` is Markdown, though it also supports some
 GOV.UK Design System specifics, as listed on [Tech Docs Template - Write your
-content](https://tdt-documentation.london.cloudapps.digital/write_docs/content/).
+content]([https://tdt-documentation.london.cloudapps.digital/write_docs/content/](https://github.com/alphagov/tdt-documentation/blob/main/source/write_docs/content/index.html.md.erb).
 
 ## Publishing changes
 
@@ -38,11 +38,11 @@ This website is hosted on [GitHub Pages](https://pages.github.com/).
 
 ### Global configuration
 
-The [GOV.UK Tech Docs Template global configuration options](https://tdt-documentation.london.cloudapps.digital/configure_project/global_configuration/)
+The [GOV.UK Tech Docs Template global configuration options]([https://tdt-documentation.london.cloudapps.digital/configure_project/global_configuration/](https://github.com/alphagov/tdt-documentation/blob/main/source/configure_project/global_configuration/index.html.md.erb)
 can be used in this repository to configure the Operations Engineering user guides.
 
 ### Structuring documentation and page configuration
 
-The [GOV.UK Tech Docs Template "Configure your documentation project"](https://tdt-documentation.london.cloudapps.digital/configure_project/)
+The [GOV.UK Tech Docs Template "Configure your documentation project"]([https://tdt-documentation.london.cloudapps.digital/configure_project/](https://github.com/alphagov/tdt-documentation/blob/main/source/configure_project/index.html.md.erb)
 offers a range of guidance regarding configuration options to help structure
 documentation and configure pages separately.


### PR DESCRIPTION
## 👀 Purpose

- Fixes a number of broken links following decommissioning of the Gov.uk Tech Docs documentation site. 

## ♻️ What's changed

- Update link to `Tech Docs Template - Write your content`
- Update link to `GOV.UK Tech Docs Template global configuration options`
- Update link to `GOV.UK Tech Docs Template "Configure your documentation project`

## 📝 Notes

- Gov.uk Tech Docs documentation can be found [here](https://github.com/alphagov/tdt-documentation)