### PR TITLE
Decrease usage threshold from80%to60%in runbook

### DIFF
--- a/source/documentation/services/sentryio/respond-to-sentry-usage-alert.html.md.erb
+++ b/source/documentation/services/sentryio/respond-to-sentry-usage-alert.html.md.erb
@@ -16,7 +16,7 @@ daily to check whether the Ministry of Justice (MoJ) Sentry quota for Errors, Tr
 > The configuration for the alert is
 >
 > - Period to check = `1 day`
-> - Usage threshold = `80%`
+> - Usage threshold = `60%`
 
 Alerts are triggered for each category when usage exceeds the threshold for a given period. The alert provides some metrics
 for context and a link to the statistics in Sentry for further investigation as shown below:


### PR DESCRIPTION
Decrease the usage threshold from 80% to 60% in the Sentry runbook.