### PR TITLE
Update responding to leavers process

### DIFF
--- a/source/documentation/internal/respond-to-leavers.html.md.erb
+++ b/source/documentation/internal/respond-to-leavers.html.md.erb
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#operations-engineering-alerts"
 title: Respond to leavers
-last_reviewed_on: 2024-01-06
+last_reviewed_on: 2024-04-08
 review_in: 3 months
 ---
 
@@ -15,20 +15,7 @@ A leaver is a user who has left the organisation.
 
 ## How will I know if a user has left the organisation?
 
-You will receive a notification in the [Operations Engineering Google Group](https://groups.google.com/u/0/a/digital.justice.gov.uk/g/operations-engineering/c/x6grUhLBiic?hl=en-GB).
-
-The message will appear in the following format:
-
-```
-Dear colleague
-
-Leaver: [username]
-Leave date: [date]
-
-Please find the details for this leaver attached.
-```
-
-Make a note of the user and date. The name won't necessarily correlate to the user's various usernames, but you should be able to decipher the email in the format of <_first_._last_@digital.justice.gov.uk>.
+Requests will come via the #ask-operations-engineering slack channel, or via email to the Operations Engineering Google Group. 
 
 ## What actions do I take?
 


### PR DESCRIPTION
## 👀 Purpose

- This PR replaces instructions relating to the old Leavers Form process that no longer exists, and adds content that reflects the current process.

## ♻️ What's changed

- Update to section `How will I know if a user has left the organisation?`