### PR TITLE
Update AWS Account Access Runbook

### DIFF
--- a/source/documentation/services/aws/aws-accounts.html.md.erb
+++ b/source/documentation/services/aws/aws-accounts.html.md.erb
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#operations-engineering-alerts"
 title: Requests for AWS Account Access
-last_reviewed_on: 2024-03-05
+last_reviewed_on: 2024-06-05
 review_in: 3 months
 ---
 
@@ -23,9 +23,7 @@ The preferred method to access an AWS account is using [AWS SSO](https://moj.aws
 
 2. Confirm with the AWS Account Owner [see AWS Account List](https://docs.google.com/spreadsheets/d/1lZ2ffiN_yQEYqTYnBzTbl16iElfrp3rZ8JnznDQWc-g/edit?usp=sharing) that the requester can have access to that account.
 
-3. If approved, add the user to the appropriate GitHub Team [see team associations](https://github.com/ministryofjustice/aws-root-account/blob/main/management-account/terraform/sso-admin-account-assignments.tf).
-
-4. Confirm to the requester when completed and send the [AWS SSO link](https://moj.awsapps.com/start/#/).
+3. If approved, direct the user to the admin/maintainer of the appropriate GitHub Team [see team associations](https://github.com/ministryofjustice/aws-root-account/blob/main/management-account/terraform/sso-admin-account-assignments.tf).
 
 ## AWS SSO Not Applicable
 


### PR DESCRIPTION
## 👀 Purpose

- The PR updates the process for granting access to AWS accounts. I have updated the process to reflect that we no longer add users directly to GitHub Teams as these are now managed by the maintainers of those GitHub Teams.

## ♻️ What's changed

- Updated steps associated with adding users to GitHub Teams.

## 📝 Notes
