### PR TITLE
✨ Add AWS Root Account Working Group Document

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 *   @ministryofjustice/operations-engineering
+/source/documentation/services/aws/aws-root-account-working-group.html.md.erb @ministryofjustice/aws-root-account-admin-team

--- a/source/documentation/services/aws/aws-root-account-working-group.html.md.erb
+++ b/source/documentation/services/aws/aws-root-account-working-group.html.md.erb
@@ -1,0 +1,38 @@
+---
+owner_slack: "#aws-root-account"
+title: AWS Root Account Working Group
+last_reviewed_on: 2024-06-05
+review_in: 3 months
+---
+
+# AWS Root Account Working Group
+
+Due to overlapping responsibility of the AWS root accounts processes (mainly with Operations Engineering and Modernisation Platform) there currently exists an AWS Working Group consisting of engineers from both teams.
+
+The working group is to ensure that processes surrounding the AWS Root account are visible and the steps to complete these processes are documented, discussed and eventually refined to minimise the requirement of higher-level permissions to enact day-to-day business processes.
+
+The members of the working group with permission to undertake the following documented processes can be found in the GitHub Team [aws-root-account-admin-team](https://github.com/orgs/ministryofjustice/teams/aws-root-account-admin-team). Members also openly discuss changes in Slack at [#aws-root-account](https://mojdt.slack.com/archives/C06P4KA0V0A)
+
+Ideally, all processes will become the responsibility of either Operations Engineering or Modernisation Platform - but for the moment, both teams are responsible via the working group.
+
+Below is a list of processes championed by the working group.
+
+## Run GitHub to AWS SCIM Job Manually
+
+### Process
+
+- SSO into the MoJ master account as an Administrator.
+- Navigate to the "Lambda" service.
+- Change your Region is set to eu-west2 (London).
+- Navigate to the "Functions" on the sidebar.
+- Select `aws-sso-scim-github`.
+- Select the `Test` tab.
+- Select `Create new event`.
+- Enter any name for the `Event name` such as `RunJobManually`.
+- Enter a blank JSON object for the test data i.e. `{}`.
+- Press the `Test` button, this will trigger the SCIM job.
+- After a couple of minutes, the job should complete and display the logs of the run. You can use the logs to confirm which users have been added to which team if the request to run the job manually came from an individual.
+
+### Issues With the Current Process
+
+- Uses full admin access (excessive privileges)

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -33,6 +33,7 @@ refer users to.
 * [AWS Credentials Remediation Process](documentation/services/aws/aws-credentials.html)
 * [Add OIDC between AWS and GitHub](documentation/services/aws/add-oidc-aws-gh.html)
 * [YJAF AWS Password Resets](documentation/services/aws/yjaf_password_reset.html)
+* [AWS Root Account Working Group](documentation/services/aws/aws-root-account-working-group.html)
 
 ## Auth0
 


### PR DESCRIPTION
## 👀 Purpose

- To allow AWS Root Account processes to be centrally documented by the current working group

## ♻️ What's changed

- Added a document that describes how to run the SCIM job manually
- Added aws-root-account-admin-team as a codeowner of the new file

## 📝 Notes

- The current document isn't all of our processes or nercericarly how we will document them, this PR is just to give the central place to the current working group