### PR TITLE
Reverse decision of ADR 013 `Archiving the DNS repo`

### DIFF
--- a/source/documentation/adrs/adr-013.html.md.erb
+++ b/source/documentation/adrs/adr-013.html.md.erb
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#operations-engineering-alerts"
 title: ADR 013 Archiving the DNS repo
-last_reviewed_on: 2024-05-13
+last_reviewed_on: 2024-06-24
 review_in: 6 months
 ---
 
@@ -9,7 +9,7 @@ review_in: 6 months
 
 ## Status
 
-✅ Accepted
+❌ Rejected
 
 ## Context
 

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -162,7 +162,7 @@ To understand why we are recording decisions and how we are doing it, please see
 | ✅      | ADR-010 | [1Password Manager Permissions](documentation/adrs/adr-010.html)           |
 | ✅      | ADR-011 | [GitHub Features as Opt In](documentation/adrs/adr-011.html)               |
 | ✅      | ADR-012 | [RSS Feed Aggregation Channel](documentation/adrs/adr-012.html)            |
-| ✅      | ADR-013 | [Archiving the DNS repo](documentation/adrs/adr-013.html)                  |
+| ❌      | ADR-013 | [Archiving the DNS repo](documentation/adrs/adr-013.html)                  |
 | ✅      | ADR-014 | [Risk Review](documentation/adrs/adr-014.html)                             |
 | ❌      | ADR-015 | [Use of GitHub Actions Runner Controller](documentation/adrs/adr-015.html) |
 | ✅      | ADR-016 | [Archive DNS-IAC](documentation/adrs/adr-016.html)                         |

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#operations-engineering-alerts"
 title: MoJ Operations Engineering Runbooks
-last_reviewed_on: 2024-05-28
+last_reviewed_on: 2024-06-24
 review_in: 6 months
 ---
 


### PR DESCRIPTION
## 👀 Purpose

- This PR updates the status of [ADR - 013](https://runbooks.operations-engineering.service.justice.gov.uk/documentation/adrs/adr-013.html) from Approved to Rejected. This is to reflect that we are now reusing this repository for the new DNS project.

## ♻️ What's changed

- Update status on runbook index
- Update status in ADR