### PR TITLE
adr-created-for-octonsdns

### DIFF
--- a/source/documentation/adrs/adr-021.html.md.erb
+++ b/source/documentation/adrs/adr-021.html.md.erb
@@ -20,7 +20,7 @@ After evaluating OctoDNS and Terraform as IaC tools, we chose OctoDNS for managi
 ## Decision
 
 - Performance tests have demonstrated that OctoDNS operations are significantly faster, offering a reliable and maintainable solution for our DNS management needs.
-- After conducting Proof of Concepts (PoCs) for both OctoDNS and Terraform, we have decided to use OctoDNS for managing our Route53 DNS records. OctoDNS eliminates the need for a state file, significantly improving efficiency and reducing complexity.
+- After conducting Proof of Concepts (PoCs) for both OctoDNS and Terraform, we have decided to use OctoDNS for managing our Route53 DNS records. OctoDNS eliminates the need for a state file, significantly improving efficiency and reducing complexity and issues.
 - Its standardised YAML configuration format is more readable and maintainable, and it integrates seamlessly with our CI/CD pipelines for automated deployment and updates. 
 - This decision addresses the key challenges we faced with Terraform and aligns with our goal to streamline and enhance DNS record management.
 

--- a/source/documentation/adrs/adr-021.html.md.erb
+++ b/source/documentation/adrs/adr-021.html.md.erb
@@ -1,0 +1,34 @@
+---
+owner_slack: "#operations-engineering-alerts"
+title: ADR-021 Management of DNS Records through OctoDNS
+last_reviewed_on: 2024-06-26
+review_in: 6 months
+---
+
+# ADR-021 Managing DNS Records Through OctoDNS
+
+## Status
+
+✅ Accepted
+
+## Context
+
+The Operations Engineering (OE) team at the Ministry of Justice (MoJ) needs to improve DNS management to address security and operational inefficiencies. Current unstructured processes lead to inconsistencies and delays.
+By gathering security stakeholder requirements, the OE team aims to make DNS management more robust, secure, and compliant, reducing manual interventions and aligning practices with MoJ's security policies
+After evaluating OctoDNS and splitting the Terraform state file by hosted zone, we chose OctoDNS for managing Route53 records. This eliminates the state file dependency, simplifies DNS record management with YAML, and integrates with our CI/CD pipelines, enhancing efficiency and maintainability
+
+## Decision
+
+- After conducting Proof of Concepts (PoCs) for both OctoDNS and Terraform, we have decided to use OctoDNS for managing our Route53 DNS records. OctoDNS eliminates the need for a state file, significantly improving efficiency and reducing complexity.
+- Its standardised YAML configuration format is more readable and maintainable, and it integrates seamlessly with our CI/CD pipelines for automated deployment and updates. Performance tests showed that OctoDNS operations are faster, providing a reliable and maintainable solution for our DNS management needs. 
+- This decision addresses the key challenges we faced with Terraform and aligns with our goal to streamline and enhance DNS record management.
+
+## Consequences
+
+- DNS records across multiple providers will be managed using a single configuration format, ensuring consistency.
+- DNS updates will be automated through our CI/CD pipelines, reducing manual effort and the potential for human error.
+- All changes to DNS records will be tracked in version control, providing a clear audit trail.
+- Built-in validation within OctoDNS will help prevent misconfigurations.
+- Initial effort will be required to integrate OctoDNS with our existing systems and pipelines.
+- OctoDNS supports a wide range of DNS providers, allowing us to manage records across different services seamlessly.
+- OctoDNS will enable scalable DNS management, allowing the team to easily handle an increasing number of domains and records as the organisation grows. This scalability ensures that the DNS management process remains efficient and manageable even as the DNS infrastructure expands.

--- a/source/documentation/adrs/adr-021.html.md.erb
+++ b/source/documentation/adrs/adr-021.html.md.erb
@@ -15,12 +15,13 @@ review_in: 6 months
 
 The Operations Engineering (OE) team at the Ministry of Justice (MoJ) needs to improve DNS management to address security and operational inefficiencies. Current unstructured processes lead to inconsistencies and delays.
 By gathering security stakeholder requirements, the OE team aims to make DNS management more robust, secure, and compliant, reducing manual interventions and aligning practices with MoJ's security policies
-After evaluating OctoDNS and splitting the Terraform state file by hosted zone, we chose OctoDNS for managing Route53 records. This eliminates the state file dependency, simplifies DNS record management with YAML, and integrates with our CI/CD pipelines, enhancing efficiency and maintainability
+After evaluating OctoDNS and Terraform as IaC tools, we chose OctoDNS for managing Route53 records. This decision eliminates the state file dependency, simplifies DNS record management with YAML, and integrates seamlessly with our CI/CD pipelines, enhancing efficiency and maintainability.
 
 ## Decision
 
+- Performance tests have demonstrated that OctoDNS operations are significantly faster, offering a reliable and maintainable solution for our DNS management needs.
 - After conducting Proof of Concepts (PoCs) for both OctoDNS and Terraform, we have decided to use OctoDNS for managing our Route53 DNS records. OctoDNS eliminates the need for a state file, significantly improving efficiency and reducing complexity.
-- Its standardised YAML configuration format is more readable and maintainable, and it integrates seamlessly with our CI/CD pipelines for automated deployment and updates. Performance tests showed that OctoDNS operations are faster, providing a reliable and maintainable solution for our DNS management needs. 
+- Its standardised YAML configuration format is more readable and maintainable, and it integrates seamlessly with our CI/CD pipelines for automated deployment and updates. 
 - This decision addresses the key challenges we faced with Terraform and aligns with our goal to streamline and enhance DNS record management.
 
 ## Consequences

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -151,7 +151,7 @@ To understand why we are recording decisions and how we are doing it, please see
 |:-------|:--------|:---------------------------------------------------------------------------|
 | ✅      | ADR-000 | [Record Architecture Decisions](documentation/adrs/adr-000.html)           |
 | ✅      | ADR-001 | [Github Failover](documentation/adrs/adr-001.html)                         |
-| ⌛️     | ADR-002 | [Sentry Spike Protection](documentation/adrs/adr-002.html)                 |
+| ⌛️      | ADR-002 | [Sentry Spike Protection](documentation/adrs/adr-002.html)                 |
 | ✅      | ADR-003 | [DNS Failover](documentation/adrs/adr-003.html)                            |
 | ✅      | ADR-004 | [Docker SSO](documentation/adrs/adr-004.html)                              |
 | ✅      | ADR-005 | [Github Standards Branch Protection](documentation/adrs/adr-005.html)      |

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -169,7 +169,8 @@ To understand why we are recording decisions and how we are doing it, please see
 | ✅      | ADR-017 | [Revert decision to mandate that repository access must be via a Team](documentation/adrs/adr-017.html) |
 | ✅      | ADR-018 | [Standardisation of Repository Naming](documentation/adrs/adr-018.html)    |
 | ✅      | ADR-019 | [Management of Github Repositories through Terraform](documentation/adrs/adr-019.html)    |
-| ✅      | ADR-020 | [Bot Account Personal Access Token Standards](documentation/adrs/adr-020.html)    |
+| ✅      | ADR-020 | [Bot Account Personal Access Token Standards](documentation/adrs/adr-020.html) |
+| ✅      | ADR-021 | [Management of DNS Records through OctoDNS](documentation/adr/adr-021.html) |
 
 **Statuses:**
 

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -170,7 +170,7 @@ To understand why we are recording decisions and how we are doing it, please see
 | ✅      | ADR-018 | [Standardisation of Repository Naming](documentation/adrs/adr-018.html)    |
 | ✅      | ADR-019 | [Management of Github Repositories through Terraform](documentation/adrs/adr-019.html)    |
 | ✅      | ADR-020 | [Bot Account Personal Access Token Standards](documentation/adrs/adr-020.html) |
-| ✅      | ADR-021 | [Management of DNS Records through OctoDNS](documentation/adr/adr-021.html) |
+| ✅      | ADR-021 | [Management of DNS Records through OctoDNS](documentation/adrs/adr-021.html) |
 
 **Statuses:**
 


### PR DESCRIPTION
ADR-Created-For-Octo-DNS in Operations Engineering Runbook.
Add an HTML page to the Operations Engineering runbook for improved documentation and accessibility.
This page will include information about Octo-DNS, our new tool for managing DNS records consistently and automatically across multiple providers.