### PR TITLE
Add secret naming convention

### DIFF
--- a/source/documentation/adrs/adr-020.html.md.erb
+++ b/source/documentation/adrs/adr-020.html.md.erb
@@ -66,4 +66,4 @@ Full examples,
 
 - These standards and conventions help to manage our current secrets manually.
 - Facilitate progress towards managing secrets automatically (storage and rotation controlled via a secrets manager).
-- Supports direction outlined in ADR 019 to enable repository secret management in Terraform.
+- Supports direction outlined in  [ADR-019](adr-019.html) to enable repository secret management in Terraform.

--- a/source/documentation/internal/add-a-runbook.html.md.erb
+++ b/source/documentation/internal/add-a-runbook.html.md.erb
@@ -10,7 +10,7 @@ review_in: 3 months
 ## To add a new runbook
 
 - Create a new `*.html.md.erb` file in the `source/documentation/<subdirectory>` directory of this repository, containing the runbook information
-- Add a corresponding list item in the `source/documentation/index.html.md.erb` file
+- Add a corresponding list item in the `source/index.html.md.erb` file
 
 > The link target should be `runbooks/documentation/<subdirectory>/[filename].html` i.e. if the runbook file is `source/documentation/certificates/foobar.html.md.erb` then the link target should be `runbooks/certificates/foobar.html`
 

--- a/source/documentation/internal/secret-naming-convention.html.md.erb
+++ b/source/documentation/internal/secret-naming-convention.html.md.erb
@@ -1,0 +1,28 @@
+---
+owner_slack: "#operations-engineering-alerts"
+title: Secret Naming Convention
+last_reviewed_on: 2024-08-05
+review_in: 3 months
+---
+
+# Secret Naming Convention
+
+The naming convention detailed below is also defined in [ADR-020](../adrs/adr-020.html) where it specifically relates to the namin of
+GitHub Personal Access Tokens in the bot account. However the required properties of the name apply to any secret created.
+
+The naming convention consists of three parts which should ensure uniqueness; `<business_domain>_<usage>_<permission_type>`
+
+- **Business domain**; this should succintly describe the business domain or blobbum for which the token is created.
+For example, `DORMANT_USERS`, `DNS`, `JOIN_GITHUB`.
+- **Usage**; this should describe the intended use of the token within the given business domain. For example,
+  - When used for everything in the business domain; `GENERAL`
+  - When used for a specific tool or integration; `SENTRY`, `SLACK`, `GITHUB`, `TERRAFORM`.
+- **Permission type**; this should indicate the amount of power the token wields. For example,
+`ADMIN`, `WRITE`, `READ` are clear and sufficient. 
+
+Examples,
+
+- `DORMANT_USERS_SLACK_ADMIN`
+- `DNS_OCTODNS_WRITE` 
+- `JOIN_GITHUB_FLASK_ADMIN`
+- `OPS_ENG_GENERAL_ADMIN`

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -141,6 +141,8 @@ refer users to.
 * [Post-Incident Review Proceses](documentation/internal/post-incident-review-proceses.html)
 * [Incident Log](documentation/internal/incident-log.html)
 * [Responding to Dependency Alerts](documentation/internal/dependency-alerts.html)
+* [Secret Naming Convention](documentation/internal/secret-naming-convention.html)
+
 
 # Architecture Decision Records
 


### PR DESCRIPTION
Create runbook for general secret naming convention; adopted via ADR-020 for GitHub PAT naming convention

R006: 🔐 Secret Naming Standard in operations-engineering [#4324](https://github.com/ministryofjustice/operations-engineering/issues/4324)

[Risk R006: 💨 Runbook For Secrets in Operations Engineering Mono Repo #4260](https://github.com/ministryofjustice/operations-engineering/issues/4260#:~:text=Risk%20R006%3A%20%F0%9F%92%A8%20Runbook%20For%20Secrets%20in%20Operations%20Engineering%20Mono%20Repo%20%234260)