### PR TITLE
Create Recycle Inactive 1Password Users Runbook

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -18,3 +18,8 @@ https://github.com/ministryofjustice/data-platform-support/issues/new/choose
 https://calendar.google.com/*
 https://github.com/organizations/ministryofjustice/settings/personal-access-token-requests
 https://github.com/organizations/moj-analytical-services/settings/personal-access-token-requests
+https://github.com/ministryofjustice/operations-engineering-reports
+https://github.com/settings/keys
+https://github.com/ministryofjustice/github-collaborators/pulls
+https://github.com/organizations/ministryofjustice/settings/installations/16911235
+https://github.com/ministryofjustice/operations-engineering/actions/workflows/dormant-users-remove-users.yml

--- a/source/documentation/services/1password/1password-inactive-users.html.md.erb
+++ b/source/documentation/services/1password/1password-inactive-users.html.md.erb
@@ -1,0 +1,30 @@
+---
+owner_slack: "#operations-engineering-alerts"
+title: Recycle Inactive User Accounts
+last_reviewed_on: 2024-08-05
+review_in: 3 months
+---
+
+# Recycle Inactive User Accounts
+
+This runbook will allow an admin to identify inactive user licences that can be suspended so that a licence can be returned to the pool for reassignment.
+
+## Pre-requisites
+
+- Organisation Admin Permissions
+
+## Identify inactive users
+
+1. Open the [Team Usage Report](https://ministryofjustice.1password.eu/insights/team-usage?filter=no-recent-usage&items-per-page=100&page-number=1&sort-by=access-date&sort-direction=desc)
+
+2. Make a note of inactive user names for suspension.
+
+## Suspend inactive users
+
+1. Navigate to the [People Dashboard](https://ministryofjustice.1password.eu/people).
+
+2. Search for the user you wish to suspend.
+
+3. Select the checkbox next to the user name.
+
+4. From the `Actions` button that appears, select `Suspend` to suspend the accout and return a licence to the available pool.

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#operations-engineering-alerts"
 title: MoJ Operations Engineering Runbooks
-last_reviewed_on: 2024-07-10
+last_reviewed_on: 2024-08-05
 review_in: 6 months
 ---
 
@@ -26,6 +26,7 @@ refer users to.
 * [Groups and Vaults](documentation/services/1password/1password-vaults-and-groups.html)
 * [1Password Chrome extension shortcut conflict](documentation/services/1password/1password-chrome-ext-conflict.html)
 * [Users unable to import via the 1Password App](documentation/services/1password/1password-import-issue.html)
+* [Recycle Inactive User Accounts](documentation/services/1password/1password-inactive-users.html)
 
 ## AWS
 


### PR DESCRIPTION
## 👀 Purpose

- This PR adds a new runbook for recycling 1Password user accounts so that we can reuse a licence if we run out of licences.

## ♻️ What's changed

- Adds Runbook
- Updates index
- Adds links behind authentication to allow list