### PR TITLE
✨ Add ADR-22 `Decommission Maintenance Pages Platform`

### DIFF
--- a/source/documentation/adrs/adr-022.html.erb.md
+++ b/source/documentation/adrs/adr-022.html.erb.md
@@ -1,0 +1,111 @@
+---
+owner_slack: "#operations-engineering-alerts"
+title: ADR 022 Decommission Maintenance Pages Platform
+last_reviewed_on: 2024-09-04
+review_in: 6 months
+---
+
+# ADR-022: Decommission Maintenance Pages Platform
+
+## Status
+
+✅ Accepted
+
+## Context
+
+The Operations Engineering team currently host a small platform built on top of the
+Cloud Platform that enables teams to quickly create a simple maintenance screen for
+a domain. This small platform is hosted as a GitHub Repository at
+[https://github.com/ministryofjustice/cloud-platform-maintenance-pages/](https://github.com/ministryofjustice/cloud-platform-maintenance-pages/).
+The application listens to various Ingress Hosts and routes these to customised views.
+
+The purpose of the Maintenance Pages Platform is to provide teams with a standardised
+maintenance page for temporary maintenance of a service or to aid when decommissioning
+a service.
+
+### Problems
+
+#### Problem Domain Not Well Understood
+
+Operations Engineering have not conducted any formal discoveries into the problem domain
+that this platform attempts to solve. There is no evidence to support that the platform,
+as is, provides value for the business or end users compared to alternative solutions.
+
+#### Operations Engineering is Unfamiliar With The Underlying Technology
+
+The application itself is written in Ruby using the Sinatra Web Framework. This stack
+is unfamiliar to the Operations Engineering team which primarily writes in Python.
+
+Due to this, even maintenance tasks such as updating dependencies can consume hours
+of engineering time. This has also contributed to the lack of maintenance for the project.
+
+#### Operations Engineering Do Not Have Time to Invest in The Platform
+
+Operations Engineering are already spread fairly thin across different domains and lack
+the time to invest into this problem domain at the moment. This problem domain also does
+not easily fit into the core offering that Operations Engineering maintains.
+
+### Symptoms
+
+#### Little Engagement With The Platform
+
+Since the platforms initial inception, 4 years ago, there has been little to no engagement
+with the platform from both existing users, new users and Operations Engineering.
+
+Since the initial on boarding of several pages, there have been no new requests for the
+platforms services. This is potentially a symptom of the platform providing minimal value
+compared to alternative solutions for teams, or the platform only being valuable to a small
+set of users/use cases, or minimal awareness throughout the organisation of the platform
+and it's services.
+
+Operations Engineering have also not maintained the platform to ensure that it is secure,
+address technical debt, and ensure the platform aligns with organisational standards due
+to lack of time to invest in the platform.
+
+## Options
+
+### 1. Keep Maintenance Pages Platform As Is
+
+**Pros**
+
+- No operational changes required for current users
+
+**Cons**
+
+- Maintenance requirements, which is time consuming for the team
+- Operations Engineering have to support technology that is does not align with the team technical skills
+- Potential burden to the business in general, since there is no evidence to support the value of the platform
+
+### 2. Invest Time Into The Problem Domain
+
+**Pros**
+
+- Potential to provide value to the business and users
+- Potential to re-align the platform to be more easily supported by the team
+- Better evidence to support the value of current or new service offerings
+
+**Cons**
+
+- Time consuming, meaning the team cannot focus on known higher value problem domains
+
+### 3. Decommission Maintenance Pages Platform
+
+**Pros**
+
+- Enables Operations Engineering to focus on higher value problems
+- Enables underlying problems in this domain to surface more naturally, which can lead to a potential new solution with less upfront investment
+
+**Cons**
+
+- Users of the platform may need to migrate off the platform, setting up a custom solution that they will then need to maintain
+
+## Decision
+
+Operations Engineering have decided on Option 3, to Decommission Maintenance Pages Platform.
+
+We have yet to fully understand the needs, business constraints and technical constraints in this area to provide a
+well-rounded solution that can meet the needs of the business and users.
+
+Understanding all of this will take time, and require the work to be prioritised by the team. Decommissioning the current
+solution will reduce the maintenance burden on the team, enabling efforts to be invested into higher priority work and
+allow the appropriate time needed to fully understand the requirements before building a new solution.

--- a/source/documentation/adrs/adr-022.html.erb.md
+++ b/source/documentation/adrs/adr-022.html.erb.md
@@ -73,7 +73,7 @@ to lack of time to invest in the platform.
 **Cons**
 
 - Maintenance requirements, which is time consuming for the team
-- Operations Engineering have to support technology that is does not align with the team technical skills
+- Operations Engineering have to support technology that does not align with the team's technical skills
 - Potential burden to the business in general, since there is no evidence to support the value of the platform
 
 ### 2. Invest Time Into The Problem Domain

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -176,6 +176,7 @@ To understand why we are recording decisions and how we are doing it, please see
 | ✅      | ADR-019 | [Management of Github Repositories through Terraform](documentation/adrs/adr-019.html)    |
 | ✅      | ADR-020 | [Bot Account Personal Access Token Standards](documentation/adrs/adr-020.html) |
 | ✅      | ADR-021 | [Management of DNS Records through OctoDNS](documentation/adrs/adr-021.html) |
+| ✅      | ADR-022 | [Decomission Maintenance Pages Platform](documentation/adrs/adr-022.html) |
 
 **Statuses:**
 


### PR DESCRIPTION
## 👀 Purpose

- In relation to https://github.com/ministryofjustice/operations-engineering/issues/4797
- To openly detail the decision to deccommission the Maintenance Pages App so that users and stakeholders are aware on the reasoning and can critique it. Also so that Operations Engineering can reflect on this decision later.

## ♻️ What's changed

- Added ADR-22 `Decommission Maintenance Pages Platform`

## 📝 Notes

- All linting issues seem to be unrelated to this PR, i.e. existing issues in the index page (but happy if someone wants to double check! 🙈)
