### PR TITLE
Fix ADR007 title

### DIFF
--- a/source/documentation/adrs/adr-007.html.md.erb
+++ b/source/documentation/adrs/adr-007.html.md.erb
@@ -1,6 +1,6 @@
 ---
 owner_slack: "#operations-engineering-alerts"
-title: ADR-007 Decomission Developer Portal
+title: ADR-007 Decommission Developer Portal
 last_reviewed_on: 2024-09-05
 review_in: 6 months
 ---

--- a/source/documentation/adrs/adr-007.html.md.erb
+++ b/source/documentation/adrs/adr-007.html.md.erb
@@ -1,6 +1,6 @@
 ---
 owner_slack: "#operations-engineering-alerts"
-title: ADR-006 Decomission Developer Portal
+title: ADR-007 Decomission Developer Portal
 last_reviewed_on: 2024-09-05
 review_in: 6 months
 ---


### PR DESCRIPTION
ADR007 has an incorrect title in the document:

- title: ADR-006 Decomission Developer Portal

Corrected to:

- title: ADR-007 Decommission Developer Portal