### PR TITLE
Remove reference to maintenance pages app in redirection runbook

### DIFF
--- a/source/documentation/dns/dns-redirect.html.md.erb
+++ b/source/documentation/dns/dns-redirect.html.md.erb
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#operations-engineering-alerts"
 title: Redirecting Domains
-last_reviewed_on: 2024-09-05
+last_reviewed_on: 2024-09-16
 review_in: 3 months
 ---
 

--- a/source/documentation/dns/dns-redirect.html.md.erb
+++ b/source/documentation/dns/dns-redirect.html.md.erb
@@ -48,7 +48,3 @@ Few things to note when creating a redirect:
 ## Redirection to gov.uk
 
 This approach is required for services that are being [transitioned to gov.uk](https://docs.publishing.service.gov.uk/manual/transition-a-site.html). This approach users a redirection service offered by GDS.
-
-## Redirection to MoJ Maintenance Pages
-
-This approach can be used for decommissioned domains or for services that need to be taken down for prolonged periods of time. This approach uses a custom created ["maintenance page"](https://github.com/ministryofjustice/cloud-platform-maintenance-pages) that is hosted on the Cloud Platform.


### PR DESCRIPTION
## 👀 Purpose

- This PR removes the option to redirect a service to the maintenance pages app. As we are decommissioning this app, this is not a suitable option.

## ♻️ What's changed

- Delete section on redirecting to maintenance pages app.