### PR TITLE
Remove reference to decommissioned pages app

### DIFF
--- a/source/documentation/dns/decommission-dns.html.md.erb
+++ b/source/documentation/dns/decommission-dns.html.md.erb
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#operations-engineering-alerts"
 title: Decommissioning Domains
-last_reviewed_on: 2024-09-05
+last_reviewed_on: 2024-09-16
 review_in: 3 months
 ---
 
@@ -22,8 +22,6 @@ To do this, navigate to the [Checking Domain Activity](https://runbooks.operatio
 ## (service).justice.gov.uk domains
 
 If the service no longer exists in any form the DNS records associated to that service can be deleted. As MoJ controls the sub-domains for service.justice.gov.uk and justice.gov.uk there is low risk that another party could reuse or register the decommissioned domain.
-
-It is optional for the domain to be redirected to the [decommissioned domains](https://github.com/ministryofjustice/cloud-platform-maintenance-pages) page. That can be discussed with the relevant Service Area.
 
 ## Services migrated to Gov.uk
 


### PR DESCRIPTION
## 👀 Purpose

- This PR removes the option to redirect a service to the decommissioned pages app. As we are decommissioning this app, this is not a suitable option.

## ♻️ What's changed

- Delete section on redirecting to decommissioned pages app.