### PR TITLE
Re-order DNS runbooks index

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#operations-engineering-alerts"
 title: MoJ Operations Engineering Runbooks
-last_reviewed_on: 2024-09-16
+last_reviewed_on: 2024-09-18
 review_in: 6 months
 ---
 
@@ -54,16 +54,14 @@ refer users to.
 ## DNS
 
 * [BT DNS Change Process Pre-requisites](documentation/dns/BT-pre-requisites.html)
-* [How to check for domain activity before decommissioning](documentation/dns/check-domain-activity.html)
-* [Decommissioning Domains](documentation/dns/decommission-dns.html)
-* [Supporting migrations/DNS cutovers](documentation/dns/dns-cutovers.html)
-* [How to manually recover deleted DNS records](documentation/dns/dns-manual-recovery.html)
-* [Redirecting Domains](documentation/dns/dns-redirect.html)
+* [Changes to Nameserver Records involving GDS Domains Team](documentation/dns/ns-changes-involving-gds.html)* [Domain Transfers for Non-gov.uk subdomains](documentation/dns/domain-transfer.html)* [Supporting migrations/DNS cutovers](documentation/dns/dns-cutovers.html)
 * [Delegation of subdomains](documentation/dns/domain-delegation.html)
-* [Domain Transfers for Non-gov.uk subdomains](documentation/dns/domain-transfer.html)
-* [Changes to Nameserver Records involving GDS Domains Team](documentation/dns/ns-changes-involving-gds.html)
-* [DNS for services using e-mail](documentation/dns/email-dns.html)
+* [Decommissioning Domains](documentation/dns/decommission-dns.html)
+* [How to check for domain activity before decommissioning](documentation/dns/check-domain-activity.html)
+* [How to manually recover deleted DNS records](documentation/dns/dns-manual-recovery.html)
 * [How to delete a Hostedzone](documentation/dns/how-to-delete-a-hostedzone.html)
+* [Redirecting Domains](documentation/dns/dns-redirect.html)
+* [DNS for services using e-mail](documentation/dns/email-dns.html)
 
 ## Docker
 

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -54,7 +54,9 @@ refer users to.
 ## DNS
 
 * [BT DNS Change Process Pre-requisites](documentation/dns/BT-pre-requisites.html)
-* [Changes to Nameserver Records involving GDS Domains Team](documentation/dns/ns-changes-involving-gds.html)* [Domain Transfers for Non-gov.uk subdomains](documentation/dns/domain-transfer.html)* [Supporting migrations/DNS cutovers](documentation/dns/dns-cutovers.html)
+* [Changes to Nameserver Records involving GDS Domains Team](documentation/dns/ns-changes-involving-gds.html)
+* [Domain Transfers for Non-gov.uk subdomains](documentation/dns/domain-transfer.html)
+* [Supporting migrations/DNS cutovers](documentation/dns/dns-cutovers.html)
 * [Delegation of subdomains](documentation/dns/domain-delegation.html)
 * [Decommissioning Domains](documentation/dns/decommission-dns.html)
 * [How to check for domain activity before decommissioning](documentation/dns/check-domain-activity.html)


### PR DESCRIPTION
## 👀 Purpose

- This PR changes the ordering of the DNS runbooks. The current order doesn't make much sense so it is being restructured  to be in a more logical order for the team to find the appropriate runbook.

## ♻️ What's changed

- Updates DNS index link order