### PR TITLE
Add new register subdomain runbooks

### DIFF
--- a/source/documentation/dns/register-new-justice-domain.html.md.erb
+++ b/source/documentation/dns/register-new-justice-domain.html.md.erb
@@ -19,6 +19,6 @@ However, we don't actually register these subdomains as we already have delegate
 
 ## Create subdomain
 
-This process just follows are standard process for adding DNS records via [DNS](https://github.com/ministryofjustice/dns).
+This process follows the standard process for adding DNS records via [DNS](https://github.com/ministryofjustice/dns).
 
-Inform requester when changes have been comppleted.
+Inform requester when changes have been completed.

--- a/source/documentation/dns/register-new-justice-domain.html.md.erb
+++ b/source/documentation/dns/register-new-justice-domain.html.md.erb
@@ -1,0 +1,24 @@
+---
+owner_slack: "#operations-engineering-alerts"
+title: Register new justice.gov.uk or service.justice.gov.uk subdomain
+last_reviewed_on: 2024-09-18
+review_in: 3 months
+---
+
+# Register new `justice.gov.uk` or `service.justice.gov.uk` subdomain
+
+The purpose of this runbook is for the registration of `justice.gov.uk` or `service.justice.gov.uk` subdomains.
+
+However, we don't actually register these subdomains as we already have delegated management of those subdomains. This is actually creation of new subdomains in the existing Hostedzones i.e. creating a DNS record.
+
+## Pre-requisites
+
+- New requests for subdomains must meet the [MoJ domain naming standard](https://technical-guidance.service.justice.gov.uk/documentation/standards/naming-domains.html#naming-domains).
+
+- Requests where delegation is involved must adhere to our rules around [delegation](https://runbooks.operations-engineering.service.justice.gov.uk/documentation/dns/domain-delegation.html).
+
+## Create subdomain
+
+This process just follows are standard process for adding DNS records via [DNS](https://github.com/ministryofjustice/dns).
+
+Inform requester when changes have been comppleted.

--- a/source/documentation/dns/register-new-service-gov-uk-subdomain.html.md.erb
+++ b/source/documentation/dns/register-new-service-gov-uk-subdomain.html.md.erb
@@ -1,0 +1,42 @@
+---
+owner_slack: "#operations-engineering-alerts"
+title: Register new service.gov.uk subdomain
+last_reviewed_on: 2024-09-18
+review_in: 3 months
+---
+
+# Register new `service.gov.uk` subdomain
+
+The purpose of this runbook is for the registration of `service.gov.uk` subdomains e.g. `example.service.gov.uk`.
+
+MoJ is unable to regsiter these domains so must register these via CDDO.
+
+## Pre-requisites
+
+Before a Service Team can apply for a service.gov.uk subdomain it must have passed a [Beta Assessment](https://www.gov.uk/service-manual/technology/get-a-domain-name#after-your-beta-assessment).
+
+Evidence of passing the assessment must be provided with the request.
+
+If a service has **not** passed Beta Assessment then a `service.justice.gov.uk` may be appropriate. See Register new justice.gov.uk or service.justice.gov.uk.
+
+## Create NS Records
+
+### DNS to be managed by Operations Engineering
+
+1. [Created a new Hostedzone](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/CreatingHostedZone.html) in AWS Route53. This is a manual step via the AWS Console. NS records created here will be needed for the registration process in the next steps.
+
+2. Add new Hostedzone to [DNS](https://github.com/ministryofjustice/dns).
+
+### DNS to be delegated to another platform
+
+1. If subdomain is being delegated to another platform ensure that the requester provides NS Record for where DNS will be managed e.g. Cloud Platform NS Records. This will be need for the registration process in the next steps.
+
+## Submit registration request to CDDO
+
+1. E-mail request for registration and delegation to CDDO domains team at [support@domains.gov.uk](mailto:support@domains.gov.uk). Include NS record details, and evidence of service passing Beta Assessment.
+
+2. CDDO will confirm when subdomain is registered and delegated.
+
+3. Confirm to the Requester that the new subdomain has been registered.
+
+After registration is complete any new DNS records for the new subdomain can be added by whoever is manageing that domain in MoJ.

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -54,8 +54,8 @@ refer users to.
 ## DNS
 
 * [Register new gov uk subdomain](documentation/dns/register-new-gov-uk-subdomain.html)
-* [Register new service.gov.uk subdomain](register-new-service-gov-uk-subdomain.html)
-* [Register new justice.gov.uk or service.justice.gov.uk subdomain](register-new-justice-domain.html)
+* [Register new service.gov.uk subdomain](documentation/dns/register-new-service-gov-uk-subdomain.html)
+* [Register new justice.gov.uk or service.justice.gov.uk subdomain](documentation/dns/register-new-justice-domain.html)
 * [BT DNS Change Process Pre-requisites](documentation/dns/BT-pre-requisites.html)
 * [Changes to Nameserver Records involving GDS Domains Team](documentation/dns/ns-changes-involving-gds.html)
 * [Domain Transfers for Non-gov.uk subdomains](documentation/dns/domain-transfer.html)

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -54,6 +54,8 @@ refer users to.
 ## DNS
 
 * [Register new gov uk subdomain](documentation/dns/register-new-gov-uk-subdomain.html)
+* [Register new service.gov.uk subdomain](register-new-service-gov-uk-subdomain.html)
+* [Register new justice.gov.uk or service.justice.gov.uk subdomain](register-new-justice-domain.html)
 * [BT DNS Change Process Pre-requisites](documentation/dns/BT-pre-requisites.html)
 * [Changes to Nameserver Records involving GDS Domains Team](documentation/dns/ns-changes-involving-gds.html)
 * [Domain Transfers for Non-gov.uk subdomains](documentation/dns/domain-transfer.html)


### PR DESCRIPTION
## 👀 Purpose

- This PR adds two new runbooks for registering types of subdomain.

## ♻️ What's changed

- Add runbook for "Register new service.gov.uk subdomain"
- Add runbook for "Register new justice.gov.uk or service.justice.gov.uk subdomain"
- Update index with new runbooks