### PR TITLE
Add `YJAF AWS IAM Account Deletion` Runbook

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -23,3 +23,6 @@ https://github.com/settings/keys
 https://github.com/ministryofjustice/github-collaborators/pulls
 https://github.com/organizations/ministryofjustice/settings/installations/16911235
 https://github.com/ministryofjustice/operations-engineering/actions/workflows/dormant-users-remove-users.yml
+https://github.com/ministryofjustice/yjaf-infra-aws-mgmt/blob/main/env_configs/yjaf-mgmt-users.tfvars
+https://github.com/ministryofjustice/yjaf-infra-aws-mgmt
+https://github.com/ministryofjustice/yjaf-infra-aws-mgmt/blob/main/user-groups/users.tf

--- a/source/documentation/services/aws/yjaf_delete_account.html.md.erb
+++ b/source/documentation/services/aws/yjaf_delete_account.html.md.erb
@@ -1,0 +1,44 @@
+---
+owner_slack: "#operations-engineering-alerts"
+title: YJAF AWS IAM Account Deletion
+last_reviewed_on: 2024-10-02
+review_in: 3 months
+---
+
+# YJAF AWS IAM Account Deletion
+
+This process covers the removal of IAM accounts for the YJAF AWS account.
+
+The existing pipelines are not able to delete accounts so there are some manual steps before you update and apply the terraform code.
+
+## Manual steps to delete IAM Account
+
+1. Access the **Youth Justice Framework Management AWS account** via [SSO](https://moj.awsapps.com/start/#/?tab=accounts).
+
+2. Go to the IAM Console.
+
+3. Click on `Users` tab.
+
+4. Click on the user name you will be deleting.
+
+5. Click on the `Security Credentials` tab
+
+6. Go to the `Multi-factor authentication (MFA)` section. Select all devices and click on the `Remove` button.
+
+7. Then click on the `Delete` button in the top right corner of the UI. You'll need to confirm deletion on the next screen and save changes. The user IAM account will now be deleted.
+
+## Update [yjaf-infra-aws-mgmt](https://github.com/ministryofjustice/yjaf-infra-aws-mgmt) and apply terraform
+
+There are two files to update:
+
+- Remove the user name for the relevant lists in the [yjaf-mgmt-users.tfvars](https://github.com/ministryofjustice/yjaf-infra-aws-mgmt/blob/main/env_configs/yjaf-mgmt-users.tfvars) file.
+
+- Remove the user module block from the [user.tf](https://github.com/ministryofjustice/yjaf-infra-aws-mgmt/blob/main/user-groups/users.tf) file.
+
+Raise a PR for changes to be reviewed by the Team. Merge changes to run aut0mated pipelines.
+
+Done
+
+
+
+

--- a/source/documentation/services/aws/yjaf_delete_account.html.md.erb
+++ b/source/documentation/services/aws/yjaf_delete_account.html.md.erb
@@ -35,6 +35,6 @@ There are two files to update:
 
 - Remove the user module block from the [user.tf](https://github.com/ministryofjustice/yjaf-infra-aws-mgmt/blob/main/user-groups/users.tf) file.
 
-Raise a PR for changes to be reviewed by the Team. Merge changes to run aut0mated pipelines.
+Raise a PR for changes to be reviewed by the Team. Merge changes to run automated pipelines.
 
 Done.

--- a/source/documentation/services/aws/yjaf_delete_account.html.md.erb
+++ b/source/documentation/services/aws/yjaf_delete_account.html.md.erb
@@ -37,8 +37,4 @@ There are two files to update:
 
 Raise a PR for changes to be reviewed by the Team. Merge changes to run aut0mated pipelines.
 
-Done
-
-
-
-
+Done.

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#operations-engineering-alerts"
 title: MoJ Operations Engineering Runbooks
-last_reviewed_on: 2024-09-19
+last_reviewed_on: 2024-10-02
 review_in: 6 months
 ---
 
@@ -35,6 +35,7 @@ refer users to.
 * [AWS Credentials Remediation Process](documentation/services/aws/aws-credentials.html)
 * [Add OIDC between AWS and GitHub](documentation/services/aws/add-oidc-aws-gh.html)
 * [YJAF AWS Password Resets](documentation/services/aws/yjaf_password_reset.html)
+* [YJAF AWS IAM Account Deletion](documentation/services/aws/yjaf_delete_account.html)
 
 ## Auth0
 


### PR DESCRIPTION
The PR adds a new runbook for deleting YJAF AWS IAM accounts