### PR TITLE
Add link to `Identify Dormant GitHub Users` workflow

### DIFF
--- a/source/documentation/services/github/remove-dormant-users.html.md.erb
+++ b/source/documentation/services/github/remove-dormant-users.html.md.erb
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#operations-engineering-alerts"
 title: How to Remove a Dormant GitHub User
-last_reviewed_on: 2024-09-05
+last_reviewed_on: 2024-10-07
 review_in: 3 months
 ---
 
@@ -81,7 +81,7 @@ Once the CSV file is uploaded to the S3 bucket, you can manually trigger the Git
 
 - Go to the GitHub repository where the GitHub Action workflow is set up.
 - Click on the **Actions** tab.
-- Find the workflow named "Identify Dormant GitHub Users".
+- Find the workflow named ["Identify Dormant GitHub Users"](https://github.com/ministryofjustice/operations-engineering/actions/workflows/exprimental-identify-dormant-github-users.yml).
 - Click **Run workflow** to start the process.
 
 ### 4. Review the Workflow Execution


### PR DESCRIPTION
## 👀 Purpose

- This PR adds a link to the GH Action Workflow. Just makes it easier to find the workflow in a growing list on this repo.

## ♻️ What's changed

- Link added