### PR TITLE
Add Modernisation Environments AWS account details

### DIFF
--- a/source/documentation/services/aws/aws-accounts.html.md.erb
+++ b/source/documentation/services/aws/aws-accounts.html.md.erb
@@ -15,6 +15,8 @@ Occasionally, we are asked by users for access to an existing AWS account.
 
 Direct the requester to the `#ask-modernisation-platform` Slack channel.
 
+In the case of existing Modernisation Platform provisioned accounts, the details and GitHub Team associations can be found in the [Modernisation Platforms Repository](https://github.com/ministryofjustice/modernisation-platform/tree/main/environments). In these instances the user will need to be added to the associated GutHub Team by an authorised repository admin or team maintainer.
+
 ## AWS Single Sign On (SSO)
 
 The preferred method to access an AWS account is using [AWS SSO](https://moj.awsapps.com/start/#/). SSO utilizes GitHub Teams to set permissions for AWS accounts.

--- a/source/documentation/services/aws/aws-accounts.html.md.erb
+++ b/source/documentation/services/aws/aws-accounts.html.md.erb
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#operations-engineering-alerts"
 title: Requests for AWS Account Access
-last_reviewed_on: 2024-09-05
+last_reviewed_on: 2024-10-07
 review_in: 3 months
 ---
 


### PR DESCRIPTION
## 👀 Purpose

This PR adds some additional information about finding Modernisation Platform (MP) AWS account associations. 

The canonical list of AWS accounts is not well maintained and does not contain all the current accounts covered by the Modernisation Platform. This  makes it more difficult to identify how users access AWS accounts; and to whom support requests should be referred. 

Adding this additional information will make MP associated accounts easier to identify, and make it easier to resolve an AWS access request.

## ♻️ What's changed

Adds link and instructions for Modernisation Platform AWS accounts.