### PR TITLE
Update runbook to include `indepedent.gov.uk` subdomains

### DIFF
--- a/source/documentation/dns/register-new-service-gov-uk-subdomain.html.md.erb
+++ b/source/documentation/dns/register-new-service-gov-uk-subdomain.html.md.erb
@@ -1,15 +1,15 @@
 ---
 owner_slack: "#operations-engineering-alerts"
-title: Register new service.gov.uk subdomain
-last_reviewed_on: 2024-09-18
+title: Register new service.gov.uk or independent.gov.uk subdomain
+last_reviewed_on: 2024-10-10
 review_in: 3 months
 ---
 
-# Register new `service.gov.uk` subdomain
+# Register new `service.gov.uk` or `independent.gov.uk` subdomain
 
-The purpose of this runbook is for the registration of `service.gov.uk` subdomains e.g. `example.service.gov.uk`.
+The purpose of this runbook is for the registration of `service.gov.uk` or `independent.gov.uk` subdomains e.g. `example.service.gov.uk` or `example.independent.gov.uk`.
 
-MoJ is unable to regsiter these domains so must register these via CDDO.
+MoJ is unable to regsiter these domains so must register these via Cabinet Office Domain Team.
 
 ## Pre-requisites
 
@@ -18,6 +18,18 @@ Before a Service Team can apply for a service.gov.uk subdomain it must have pass
 Evidence of passing the assessment must be provided with the request.
 
 If a service has **not** passed Beta Assessment then a `service.justice.gov.uk` may be appropriate. See Register new justice.gov.uk or service.justice.gov.uk.
+
+The above does not apply to `independent.gov.uk` subdomains.
+
+As part of the process you will need to provide the following information to the Cabinet Office Domain Team as part of the request:
+- Service name
+- Short service description
+- Details of the Service Owner
+- Details of the Service Tech Lead
+- Details of the Team/Squad running the project
+- Name Servers details
+- AWS account number where domain is hosted
+- Hosted Zone ID
 
 ## Create NS Records
 
@@ -33,9 +45,9 @@ If a service has **not** passed Beta Assessment then a `service.justice.gov.uk` 
 
 ## Submit registration request to CDDO
 
-1. E-mail request for registration and delegation to CDDO domains team at [support@domains.gov.uk](mailto:support@domains.gov.uk). Include NS record details, and evidence of service passing Beta Assessment.
+1. E-mail request for registration and delegation to Cabinet Office Domains Team at [domains@cabinetoffice.gov.uk](mailto:domains@cabinetoffice.gov.uk). Include pre-requisite information, and evidence of service passing Beta Assessment (if appropriate).
 
-2. CDDO will confirm when subdomain is registered and delegated.
+2. Cabinet Office will confirm when subdomain is registered and delegated.
 
 3. Confirm to the Requester that the new subdomain has been registered.
 


### PR DESCRIPTION
## 👀 Purpose

- This PR adds guidance to the existing runbook for `indepedent.gov.uk` which follow a similar journey to the process for `service.gov.uk domains`

## ♻️ What's changed

- Update runbook to include references to `indepedent.gov.uk`
- Add additional prerequisites
- Update Cabinet Office domain team email address