### PR TITLE
🆙 Update `tech-docs-github-pages-publisher` to v5.0.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,25 +3,33 @@ name: Build gh-pages
 on:
   workflow_dispatch:
   pull_request:
-    types: [opened, edited, reopened, synchronize]
 
 jobs:
   build:
+    name: Build
     runs-on: ubuntu-latest
     container:
-      image: ministryofjustice/tech-docs-github-pages-publisher:v3
+      image: ghcr.io/ministryofjustice/tech-docs-github-pages-publisher@sha256:35699473dbeefeeb8b597de024125a241277ee03587d5fe8e72545e4b27b33f8 # v5.0.0
+    permissions:
+      contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-      - name: Compile Markdown to HTML and create artifact
+        id: checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Build
+        id: build
         run: |
-          /scripts/deploy.sh
-      - name: Upload artifact to be URL checked
-        uses: actions/upload-artifact@v3
+          /usr/local/bin/package
+
+      - name: Upload Artifact
+        id: upload_artifact
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
-          name: github-pages-test
+          name: github-pages
           path: artifact.tar
           retention-days: 1
+          overwrite: true
 
   linkChecker:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,34 +21,50 @@ concurrency:
 
 jobs:
   build:
+    name: Build
     runs-on: ubuntu-latest
     container:
-      image: ministryofjustice/tech-docs-github-pages-publisher:v3.0.1
+      image: ghcr.io/ministryofjustice/tech-docs-github-pages-publisher@sha256:35699473dbeefeeb8b597de024125a241277ee03587d5fe8e72545e4b27b33f8 # v5.0.0
+    permissions:
+      contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-      - name: Compile Markdown to HTML and create artifact
+        id: checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Build
+        id: build
         run: |
-          /scripts/deploy.sh
-      - name: Upload artifact to be published
-        uses: actions/upload-artifact@v3
+          /usr/local/bin/package
+
+      - name: Upload Artifact
+        id: upload_artifact
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
           name: github-pages
           path: artifact.tar
           retention-days: 1
+          overwrite: true
 
-  deploy:
+  publish:
     needs: build
+    name: Publish
+    runs-on: ubuntu-latest
     environment:
       name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
+      url: ${{ steps.configure_pages.outputs.base_url }}
+    permissions:
+      contents: read
+      id-token: write
+      pages: write
     steps:
-      - name: Setup Pages
-        uses: actions/configure-pages@v3
+      - name: Configure Pages
+        id: configure_pages
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
+
       - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v2
+        id: deploy_pages
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
 
   linkChecker:
     runs-on: ubuntu-latest

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -26,3 +26,4 @@ https://github.com/ministryofjustice/operations-engineering/actions/workflows/do
 https://github.com/ministryofjustice/yjaf-infra-aws-mgmt/blob/main/env_configs/yjaf-mgmt-users.tfvars
 https://github.com/ministryofjustice/yjaf-infra-aws-mgmt
 https://github.com/ministryofjustice/yjaf-infra-aws-mgmt/blob/main/user-groups/users.tf
+https://hub.docker.com/orgs/ministryofjustice/members

--- a/source/javascripts/govuk_frontend.js
+++ b/source/javascripts/govuk_frontend.js
@@ -1,0 +1,1 @@
+//= require govuk_frontend_all


### PR DESCRIPTION
## 👀 Purpose

- To ensure we keep of technical debt by bumping up major versions
- To test v5 of the tech-docs-publisher before releasing it

## ♻️ What's changed

- Updated `tech-docs-github-pages-publisher` to v5.0.0 and implementing the new changes required for upgrading to v4 and v5