### PR TITLE
removed moj github actions paragraph

### DIFF
--- a/source/documentation/internal/team/ways-of-engineering.html.erb.md
+++ b/source/documentation/internal/team/ways-of-engineering.html.erb.md
@@ -39,14 +39,6 @@ To enhance our security posture and streamline the management of vulnerabilities
 
 To uphold the highest security standards in our Python codebase, we have decided to integrate CodeQL into our development workflow. CodeQL will serve as a critical tool in identifying security weaknesses within our Python code at pull request (PR) stages and on a regular basis through automated scans. Including CodeQL aims to enhance our proactive security measures, allowing us to address vulnerabilities effectively and maintain the integrity of our applications.
 
-## **Third Party Tooling Dependency Management**
-
-### **💡 Maintain MoJ GitHub Actions**
-
-We introduce dependency whenever we decide to use a third party GitHub Action, this is an action not maintained by GitHub themselves, but nevertheless available on the GitHub Actions Marketplace. We can estimate the risk by number of likes, maintenance history, number of contributors, etc but sometimes there is little choice for the particular action required. Here we make a decision between spending time creating the action ourselves (and maintaining it henceforth) and the as yet unknown risk of using an untested tool. So far we have generally chosen the latter, however there are some issues arising with reliability and maintainability which incur effort to untangle; effort which could be better spent maintaining our own version of the action. Doing so would give us full control over the action, the ability to keep it simple, the ongoing effort put into maintaining it could be considered slightly less wasteful than effort put into debugging someone else's code. We could develop a standard way of writing GitHub Actions, and split each into their own repository inevitably culminating in a refactor [ministryofjustice/github-actions](https://github.com/ministryofjustice/github-actions). Standardisation of existing and new MoJ GitHub Actions would reduce the maintenance burden by increasing familiarity.
-
----
-
 ## Adding/Adjusting Ways of Engineering
 
 To maintain the relevance and effectiveness of our Ways of Engineering, we encourage team members to propose adjustments or additions. Suggestions can be discussed in dedicated Slack channels, Engineering Guild meetings, or directly through Pull Requests. Your contributions are crucial in ensuring our engineering practices remain dynamic, inclusive, and aligned with our goals.


### PR DESCRIPTION
PR removes "Maintain MoJ GitHub Actions" from Ways of Engineering