### PR TITLE
Add Runbook to identify unused PagerDuty licences

### DIFF
--- a/source/documentation/services/pagerduty/identify-unused-licence.html.md.erb
+++ b/source/documentation/services/pagerduty/identify-unused-licence.html.md.erb
@@ -1,0 +1,26 @@
+---
+owner_slack: "#operations-engineering-alerts"
+title: Identify Unused Pagerduty Licences
+last_reviewed_on: 2024-12-05
+review_in: 3 months
+---
+
+# Identify Unused Pagerduty Licences
+
+If running low on licences we can remove users who have not accepted an invite. You can use the [PagerDuty Onboarding Report](https://support.pagerduty.com/main/docs/user-onboarding-report) to identify users who have never accpeted an invite.
+
+## Pre-requisites
+
+Before you begin, there are a few pre-requisites:
+
+- PagerDuty Admin access
+
+## User Onboarding Report
+
+1. Navigate to the [User Onboarding Report](https://moj-digital-tools.pagerduty.com/analytics/dashboards/user-onboarding/P5OExfzET_QdUAcL1yI1Ng) (the report can be found under the Analytics tab).
+
+2. Review report and identify users with a `Accepted Invite` value of `No`.
+
+3. You can click on the users name from the report to access the users profile. Click on the **Delete** button to remove the user.
+
+4. Repeat to free up as many licences as you can.

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#operations-engineering-alerts"
 title: MoJ Operations Engineering Runbooks
-last_reviewed_on: 2024-11-22
+last_reviewed_on: 2024-12-05
 review_in: 6 months
 ---
 
@@ -93,6 +93,7 @@ refer users to.
 ## PagerDuty
 
 * [Add a new Slack channel to a PagerDuty service](documentation/services/pagerduty/add-slack-channel.html)
+* [Identify Unused PagerDuty Licences](documentation/services/pagerduty/identify-unused-licence.html)
 
 ## Renovate
 


### PR DESCRIPTION
## 👀 Purpose

- This PR adds a new runbook for identifying unused PagerDuty licences.

## ♻️ What's changed

- Add runbook `Identify Unused PagerDuty Licences`
- Update index