### PR TITLE
Add BT DNS to leavers guide

### DIFF
--- a/source/documentation/internal/team/leavers.html.erb.md
+++ b/source/documentation/internal/team/leavers.html.erb.md
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#operations-engineering-alerts"
 title: Leavers Guide
-last_reviewed_on: 2024-11-04
+last_reviewed_on: 2025-01-10
 review_in: 3 months
 ---
 
@@ -33,13 +33,13 @@ This is not just about returning their Mac - it will do the important step of cl
 
 6. Remove them from the following Google Groups:
 
-- <operations-engineering@digital.justice.gov.uk> `https://groups.google.com/a/digital.justice.gov.uk/g/operations-engineering?hl=en-GB`
+  - <operations-engineering@digital.justice.gov.uk> `https://groups.google.com/a/digital.justice.gov.uk/g/operations-engineering?hl=en-GB`
 
-- <domains@digital.justice.gov.uk> `https://groups.google.com/a/digital.justice.gov.uk/g/domains?hl=en-GB`
+  - <domains@digital.justice.gov.uk> `https://groups.google.com/a/digital.justice.gov.uk/g/domains?hl=en-GB`
 
-- <certificates@digital.justice.gov.uk> `https://groups.google.com/a/digital.justice.gov.uk/g/certificates?hl=en-GB`
+  - <certificates@digital.justice.gov.uk> `https://groups.google.com/a/digital.justice.gov.uk/g/certificates?hl=en-GB`
 
-- <certificate_alerts@digital.justice.gov.uk> `https://groups.google.com/a/digital.justice.gov.uk/g/certificate_alerts?hl=en-GB`
+  - <certificate_alerts@digital.justice.gov.uk> `https://groups.google.com/a/digital.justice.gov.uk/g/certificate_alerts?hl=en-GB`
 
 7. Remove them from [Sentry.io](https://sentry.io)
 
@@ -48,6 +48,8 @@ This is not just about returning their Mac - it will do the important step of cl
 9. Remove them from [PagerDuty](https://www.pagerduty.com/)
 
 10. Remove them from [Auth0](https://www.auth0.com/)
+
+11. Remove them from [BT DNS](https://www.dmc.bt.com/)
 
 ## Line manager actions
 


### PR DESCRIPTION
The PR adds removal from BT DNS to the leavers guide.