### PR TITLE
Add OS Datahub Team Spaces Runbook

### DIFF
--- a/source/documentation/services/osdatahub/os_datahub_team_spaces.html.md.erb
+++ b/source/documentation/services/osdatahub/os_datahub_team_spaces.html.md.erb
@@ -1,0 +1,40 @@
+---
+owner_slack: "#operations-engineering-alerts"
+title: OS Data Hub Team Space Creation
+last_reviewed_on: 2025-03-03
+review_in: 3 months
+---
+
+# OS Data Hub API Key Management
+
+The [OS Data Hub](https://osdatahub.os.uk/) is the MoJ's product of choice for incorporating gepgraphic data into applications.
+
+[Team Spaces](https://osdatahub.os.uk/support/teamSpaces) is a feature that enables Teams to restrict access to projects/API keys.
+
+## Pre-requisites
+
+You must have access to the [OS Data Hub](https://osdatahub.os.uk/). If not, please contact your [administrator](mailto:operations-engineering@digital.justice.gov.uk).
+
+## Creating a new Team Space
+
+1. Login the the [OS Data Hub](https://osdatahub.os.uk/)
+
+2. Go to "Team Spaces"
+
+3. Click "Create Team Space"
+
+4. Enter a "Name" in the format `<Business Unit> <Application>`
+
+> e.g. `HMCTS Appellant in Person`
+
+5. Enter a "Description" (optional)
+
+6. Click "Next" button
+
+7. Click on the "Members" tab
+
+8. Turn on "Lock this Team Space"
+
+9. Add Team members to the team
+
+10. Click "Create Team Space" button to save

--- a/source/documentation/services/osdatahub/os_datahub_team_spaces.html.md.erb
+++ b/source/documentation/services/osdatahub/os_datahub_team_spaces.html.md.erb
@@ -5,7 +5,7 @@ last_reviewed_on: 2025-03-03
 review_in: 3 months
 ---
 
-# OS Data Hub API Key Management
+# OS Data Hub Team Space Creation
 
 The [OS Data Hub](https://osdatahub.os.uk/) is the MoJ's product of choice for incorporating gepgraphic data into applications.
 

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#operations-engineering-alerts"
 title: MoJ Operations Engineering Runbooks
-last_reviewed_on: 2025-02-10
+last_reviewed_on: 2025-03-03
 review_in: 6 months
 ---
 
@@ -90,6 +90,7 @@ refer users to.
 ## OS Data Hub
 
 * [OS Data Hub API Key Management](documentation/services/osdatahub/api-key-management.html)
+* [OS Data Hub Team Spaces](documentation/services/osdatahub/os_datahub_team_spaces.html)
 
 ## PagerDuty
 


### PR DESCRIPTION
## 👀 Purpose

- This PR adds a new runbook for creation of OS Datahub Team Spaces

## ♻️ What's changed

- Add new runbook
- Update index
