### PR TITLE
Create runbook to add users to OS DataHub

### DIFF
--- a/source/documentation/services/osdatahub/os-datahub-invite-user.html.md.erb
+++ b/source/documentation/services/osdatahub/os-datahub-invite-user.html.md.erb
@@ -21,7 +21,7 @@ You must have admin access to the [OS Data Hub](https://osdatahub.os.uk/).
 
 2. In the top right corner click on your name and select **Account**.
 
-3. Then on the left and side select **Manage team members**.
+3. Then on the left hand side select **Manage team members**.
 
 4. Click on the **Invite team members** button.
 

--- a/source/documentation/services/osdatahub/os-datahub-invite-user.html.md.erb
+++ b/source/documentation/services/osdatahub/os-datahub-invite-user.html.md.erb
@@ -7,7 +7,7 @@ review_in: 6 months
 
 # Invite user to OS Datahub
 
-The [OS Data Hub](https://osdatahub.os.uk/) is the MoJ's product of choice for incorporating gepgraphic data into applications.
+The [OS Data Hub](https://osdatahub.os.uk/) is the MoJ's product of choice for incorporating geographic data into applications.
 
 The hub is self service, but users must be invited to the MoJ account in the first instance.
 

--- a/source/documentation/services/osdatahub/os-datahub-invite-user.html.md.erb
+++ b/source/documentation/services/osdatahub/os-datahub-invite-user.html.md.erb
@@ -1,0 +1,30 @@
+---
+owner_slack: "#operations-engineering-alerts"
+title: Invite user to OS DataHub
+last_reviewed_on: 2025-04-15
+review_in: 6 months
+---
+
+# Invite user to OS Datahub
+
+The [OS Data Hub](https://osdatahub.os.uk/) is the MoJ's product of choice for incorporating gepgraphic data into applications.
+
+The hub is self service, but users must be invited to the MoJ account in the first instance.
+
+## Pre-requisites
+
+You must have admin access to the [OS Data Hub](https://osdatahub.os.uk/).
+
+## Invite user
+
+1. Login the the [OS Data Hub](https://osdatahub.os.uk/).
+
+2. In the top right corner click on your name and select **Account**.
+
+3. Then on the left and side select **Manage team members**.
+
+4. Click on the **Invite team members** button.
+
+5. In the pop-up, select **User** and add their email address in the email box.
+
+6. Click on the **Add team member** button to issue the invite. You will return to the **Manage team members** page. 

--- a/source/documentation/services/osdatahub/os-datahub-invite-user.html.md.erb
+++ b/source/documentation/services/osdatahub/os-datahub-invite-user.html.md.erb
@@ -17,7 +17,7 @@ You must have admin access to the [OS Data Hub](https://osdatahub.os.uk/).
 
 ## Invite user
 
-1. Login the the [OS Data Hub](https://osdatahub.os.uk/).
+1. Login to the [OS Data Hub](https://osdatahub.os.uk/).
 
 2. In the top right corner click on your name and select **Account**.
 

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#operations-engineering-alerts"
 title: MoJ Operations Engineering Runbooks
-last_reviewed_on: 2025-03-03
+last_reviewed_on: 2025-05-15
 review_in: 6 months
 ---
 
@@ -89,6 +89,7 @@ refer users to.
 
 ## OS Data Hub
 
+* [OS Data Hub API Key Management](documentation/services/osdatahub/os-datahub-invite-user.html)
 * [OS Data Hub API Key Management](documentation/services/osdatahub/api-key-management.html)
 * [OS Data Hub Team Spaces](documentation/services/osdatahub/os_datahub_team_spaces.html)
 


### PR DESCRIPTION
This PR adds a runbook for adding users to OS Datahub. This is part of handover documentation.