### PR TITLE
Update review dates

### DIFF
--- a/source/documentation/adrs/adr-017.html.erb.md
+++ b/source/documentation/adrs/adr-017.html.erb.md
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#operations-engineering-alerts"
 title: ADR 017 Revert decision to mandate that repository access must be via a Team
-last_reviewed_on: 2024-12-18
+last_reviewed_on: 2025-06-18
 review_in: 6 months
 ---
 

--- a/source/documentation/dns/register-new-gov-uk-subdomain.html.md.erb
+++ b/source/documentation/dns/register-new-gov-uk-subdomain.html.md.erb
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#operations-engineering-alerts"
 title: Register new gov.uk subdomain
-last_reviewed_on: 2025-03-18
+last_reviewed_on: 2025-06-18
 review_in: 3 months
 ---
 


### PR DESCRIPTION
This PR updates the review dates for the following documents:

- [ADR 017 Revert decision to mandate that repository access must be via a Team](https://runbooks.operations-engineering.service.justice.gov.uk/documentation/adrs/adr-017.html)
- [Register new gov.uk subdomain](https://runbooks.operations-engineering.service.justice.gov.uk/documentation/dns/register-new-gov-uk-subdomain.html)