### PR TITLE
Add Design System and CircleCI to unsupported list

### DIFF
--- a/source/documentation/services/we-dont-do-that.html.md.erb
+++ b/source/documentation/services/we-dont-do-that.html.md.erb
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#operations-engineering-alerts"
 title: Services we don't manage
-last_reviewed_on: 2025-04-14
+last_reviewed_on: 2025-06-23
 review_in: 3 months
 ---
 
@@ -20,6 +20,10 @@ Redirect the user to #ask-digital-studio-ops Slack channel
 ## BrowserStack
 
 Redirect user to #digital_it_forum Slack channel
+
+## CircleCI
+
+Redirect user to #visitor-moj-circleci Slack channel
 
 ## Cloud Platform related requests
 
@@ -61,6 +65,10 @@ Redirect user to #digital_it_forum Slack channel
 ## Modernisation Platform related requests
 
 Redirect user to #ask-modernisation-platform Slack channel
+
+## MoJ Design System
+
+Redirect user to #moj-design-system-support Slack channel
 
 ## MS Teams
 


### PR DESCRIPTION
This PR adds the MoJ Design System and CircleCI to the unsupported services list and their respective alternative support channels.